### PR TITLE
Luckfox Pico: Set BTF-Disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Armbian + Meshtastic == mPWRD OS
 | RK3506B  | 🦊 Luckfox Lyra Zero W   | WIP    |
 | RK3506J  | 🐈 ForLinx OK3506-S12    | WIP    |
 | RV1106G  | 🦊 Luckfox Pico Max      | WIP    |
-| RV1103   | 🦊 Luckfox Pico Mini     | WIP    |
+| RV1103G  | 🦊 Luckfox Pico Mini     | WIP    |
+| RV1103B  | 🧅 OnionIOT Omega4       | Todo   |
 | BCM2711  | 🍓 Raspberry Pi (64-bit) | WIP    |
 | UEFI     | 🖥️ Generic x86_64 UEFI   | Dev    |
 

--- a/config-forlinx-ok3506-s12.conf
+++ b/config-forlinx-ok3506-s12.conf
@@ -13,4 +13,3 @@ BOARD=forlinx-ok3506-s12
 #BRANCH=current
 BRANCH=vendor
 #BRANCH=edge
-

--- a/config-luckfox-pico-max.conf
+++ b/config-luckfox-pico-max.conf
@@ -13,4 +13,4 @@ BOARD=luckfox-pico-max
 #BRANCH=current
 BRANCH=vendor
 #BRANCH=edge
-
+KERNEL_BTF=no

--- a/config-luckfox-pico-mini.conf
+++ b/config-luckfox-pico-mini.conf
@@ -13,4 +13,4 @@ BOARD=luckfox-pico-mini
 #BRANCH=current
 BRANCH=vendor
 #BRANCH=edge
-
+KERNEL_BTF=no


### PR DESCRIPTION
Explicitly disable BTF to save memory on RV1106 family