### PR TITLE
performance extension: enable perf extensions for pico mini

### DIFF
--- a/config-luckfox-pico-mini.conf
+++ b/config-luckfox-pico-mini.conf
@@ -4,4 +4,4 @@ source family-rv1106.conf
 
 # Board-specific
 BOARD=luckfox-pico-mini
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,disable-bg-apt"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,disable-bg-apt,fixed-eth-mac,perf-sources,perf-journald,perf-sysctl,perf-apt,perf-fstab-noatime"


### PR DESCRIPTION
Updates the pico‑mini config to extend ENABLE_EXTENSIONS with the perf and apt\ntuning set for low‑RAM images.