### PR TITLE
rv1106: drop networking stack override

### DIFF
--- a/family-rv1106.conf
+++ b/family-rv1106.conf
@@ -5,9 +5,5 @@ BRANCH=vendor
 #BRANCH=current
 #BRANCH=edge
 
-# Use networkd; Armbian-default on Minimal images.
-# It's lighter, though not as full-featured as NetworkManager.
-NETWORKING_STACK="systemd-networkd"
-
 # Family-specific extensions (optimizations)
 ENABLE_EXTENSIONS="fixed-eth-mac"


### PR DESCRIPTION
Remove the explicit NETWORKING_STACK setting from family-rv1106.conf so the default networking stack applies. This keeps Luckfox Pico Mini more uniform with other board families. NetworkManager runs well on Luckfox Pico Mini; RAM idles just below ~1MB and peaks around ~10MB. In testing, total CPU time over ~21 hours was ~12 seconds.