### PR TITLE
Install i2c-tools in images

### DIFF
--- a/customize-image.sh
+++ b/customize-image.sh
@@ -23,6 +23,7 @@ Main() {
 			AddMeshtasticRepo_Debian_OBS
 			InstallAptPkg "meshtasticd"
 			InstallAptPkg "pipx"
+			InstallAptPkg "i2c-tools"
 			InstallAptPkg "cockpit cockpit-networkmanager"
 			InstallPipxPkg "meshtastic"
 			InstallPipxPkg "contact"
@@ -31,6 +32,7 @@ Main() {
 			AddMeshtasticRepo_Debian_OBS
 			InstallAptPkg "meshtasticd"
 			InstallAptPkg "pipx"
+			InstallAptPkg "i2c-tools"
 			InstallAptPkg "cockpit cockpit-networkmanager"
 			# pipx too old for global InstallPipxPkg on bookworm
 			;;
@@ -38,6 +40,7 @@ Main() {
 			AddMeshtasticRepo_Ubuntu_PPA
 			InstallAptPkg "meshtasticd"
 			InstallAptPkg "pipx"
+			InstallAptPkg "i2c-tools"
 			InstallAptPkg "cockpit cockpit-networkmanager"
 			# pipx too old for global InstallPipxPkg on noble
 			;;


### PR DESCRIPTION
Add i2c-tools under pipx installs for trixie, bookworm, and noble.