### PR TITLE
Set default MacAddressSource at build-time.

### DIFF
--- a/customize-image.sh
+++ b/customize-image.sh
@@ -145,15 +145,26 @@ EnableUserDTOverlay() {
 	fi
 } # EnableUserDTOverlay
 
+MTSetMacSrc() {
+	iface_name="$1"
+	# Set the General.MACAddressSource to $iface_name
+	# for meshtasticd (/etc/meshtasticd/config.yaml)
+	sed -i "s/^#\?  MACAddressSource: .*/  MACAddressSource: $iface_name/" /etc/meshtasticd/config.yaml
+} # MTSetMacSrc
+
 BoardSpecific() {
 	case $BOARD in
 		forlinx-ok3506-s12)
 			# Enable forlinx-ok3506-s12-spi0-1cs-spidev overlay
 			EnableUserDTOverlay "forlinx-ok3506-s12-spi0-1cs-spidev"
+			# Set meshtasticd MacAddressSource to 'end1' for forlinx-ok3506-s12
+			MTSetMacSrc "end1"
 			;;
 		luckfox-lyra-plus)
 			# Enable luckfox-lyra-plus-spi0-1cs_rmio13-spidev overlay
 			EnableUserDTOverlay "luckfox-lyra-plus-spi0-1cs_rmio13-spidev"
+			# Set meshtasticd MacAddressSource to 'end1' for lyra-plus
+			MTSetMacSrc "end1"
 			# Download waveshare pico config for lyra-plus
 			curl -fsSL https://github.com/meshtastic/firmware/raw/607b631114349234b8859c2da0d0f553b3d344f3/bin/config.d/lora-lyra-ws-raspberry-pi-pico-hat.yaml \
 				-o /etc/meshtasticd/config.d/lora-lyra-ws-raspberry-pi-pico-hat.yaml
@@ -161,6 +172,8 @@ BoardSpecific() {
 		luckfox-lyra-ultra-w)
 			# Enable luckfox-lyra-ultra-w-spi0-1cs-spidev overlay
 			EnableUserDTOverlay "luckfox-lyra-ultra-w-spi0-1cs-spidev"
+			# Set meshtasticd MacAddressSource to 'end1' for lyra-ultra-w
+			MTSetMacSrc "end1"
 			# Download 'Luckfox Ultra' 2W hat config for lyra-ultra
 			curl -fsSL https://raw.githubusercontent.com/meshtastic/firmware/607b631114349234b8859c2da0d0f553b3d344f3/bin/config.d/lora-lyra-ultra_2w.yaml \
 				-o /etc/meshtasticd/config.d/lora-lyra-ultra_2w.yaml
@@ -169,13 +182,21 @@ BoardSpecific() {
 			# Enable luckfox-lyra-zero-w-spi0-1cs-spidev overlay
 			EnableUserDTOverlay "luckfox-lyra-zero-w-spi0-1cs-spidev"
 			;;
+		luckfox-pico-max)
+			# Set meshtasticd MacAddressSource to 'eth0' for pico-max
+			MTSetMacSrc "eth0"
+			;;
 		luckfox-pico-mini)
+			# Set meshtasticd MacAddressSource to 'eth0' for pico-mini
+			MTSetMacSrc "eth0"
 			# Copy femtofox config for pico-mini
 			cp /etc/meshtasticd/available.d/femtofox/femtofox_SX1262_TCXO.yaml /etc/meshtasticd/config.d/
 			;;
 		# raspberry-pi-64bit
 		rpi4b)
 			# Setup devicetree overlay for SPI stuff
+			# TODO Set meshtasticd MacAddressSource to 'eth0' for rpi4b
+			# MTSetMacSrc "eth0"
 			;;
 		*)
 			echo "No board-specific customizations for board: $BOARD"


### PR DESCRIPTION
Add function (a simple `sed`) to set meshtasticd `MacAddressSource` at build-time.