### PR TITLE
perf-apt: restore upstream snapshot ignore rule

### DIFF
--- a/extensions/performance/perf-apt.sh
+++ b/extensions/performance/perf-apt.sh
@@ -12,6 +12,8 @@ function pre_umount_final_image__perf_apt_apply() {
 	Acquire::Queue-Mode "access";
 	Acquire::http::No-Cache "true";
 	Acquire::http::Pipeline-Depth "0";
+	// perf-sources ships *.upstream source snapshots; ignore them silently.
+	Dir::Ignore-Files-Silently:: "\.upstream$";
 	Dir::Cache::pkgcache "";
 	Dir::Cache::srcpkgcache "";
 


### PR DESCRIPTION
restore the .upstream Ignore-Files-Silently rule removed in 6dd93f6 so perf-sources snapshot files stay quiet during apt operations