### PR TITLE
Use a dedicated driver for the Osoyoo 7-inch DSI panel

### DIFF
--- a/config-luckfox-lyra-zero-w.conf
+++ b/config-luckfox-lyra-zero-w.conf
@@ -15,7 +15,7 @@ function custom_kernel_config__lyra_zero_osoyoo_7inch_dsi() {
 	)
 
 	opts_m+=(
-		DRM_PANEL_SIMPLE
+		DRM_PANEL_OSOYOO_DSI
 		REGULATOR_RASPBERRYPI_TOUCHSCREEN_V2
 	)
 }

--- a/config-luckfox-lyra-zero-w.conf
+++ b/config-luckfox-lyra-zero-w.conf
@@ -5,3 +5,17 @@ source family-rk3506.conf
 # Board-specific
 BOARD=luckfox-lyra-zero-w
 ENABLE_EXTENSIONS="unblock-rfkill"
+
+# Enable the minimal kernel pieces needed for the Osoyoo 7-inch DSI panel
+# overlay on Lyra Zero W. The overlay is opt-in and does not replace the
+# existing default display path.
+function custom_kernel_config__lyra_zero_osoyoo_7inch_dsi() {
+	opts_y+=(
+		TOUCHSCREEN_GOODIX
+	)
+
+	opts_m+=(
+		DRM_PANEL_SIMPLE
+		REGULATOR_RASPBERRYPI_TOUCHSCREEN_V2
+	)
+}

--- a/config-luckfox-lyra-zero-w.conf
+++ b/config-luckfox-lyra-zero-w.conf
@@ -6,12 +6,18 @@ source family-rk3506.conf
 BOARD=luckfox-lyra-zero-w
 ENABLE_EXTENSIONS="unblock-rfkill"
 
-# Enable the minimal kernel pieces needed for the Osoyoo 7-inch DSI panel
-# overlay on Lyra Zero W. The overlay is opt-in and does not replace the
-# existing default display path.
+# Enable the kernel pieces needed for the Osoyoo 7-inch DSI panel and
+# framebuffer console on Lyra Zero W.
 function custom_kernel_config__lyra_zero_osoyoo_7inch_dsi() {
 	opts_y+=(
+		FB
+		FRAMEBUFFER_CONSOLE
+		FRAMEBUFFER_CONSOLE_ROTATION
+		FONT_8x16
+		DRM_FBDEV_EMULATION
 		TOUCHSCREEN_GOODIX
+		VT
+		VT_CONSOLE
 	)
 
 	opts_m+=(

--- a/kernel/rk35xx-vendor-6.1/0001-regulator-rpi-panel-v2-add-osoyoo-compatible.patch
+++ b/kernel/rk35xx-vendor-6.1/0001-regulator-rpi-panel-v2-add-osoyoo-compatible.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Developer <developer@example.com>
+Date: Fri, 3 Apr 2026 00:00:00 +0000
+Subject: [PATCH] regulator: rpi-panel-v2: add Osoyoo 7-inch compatible
+
+The Osoyoo 7-inch 720x1280 DSI panel uses the same I2C MCU register model as
+the Raspberry Pi Touch Display 2 backlight regulator, but reports revision
+0x07 instead of the Raspberry Pi-specific revisions currently allowed by the
+driver.
+
+Add an Osoyoo-compatible OF match so the driver can bind without replacing the
+existing Raspberry Pi path, and allow revision 0x07 only for that compatible.
+---
+ drivers/regulator/rpi-panel-v2-regulator.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/regulator/rpi-panel-v2-regulator.c b/drivers/regulator/rpi-panel-v2-regulator.c
+index 9396445f0867..000000000000 100644
+--- a/drivers/regulator/rpi-panel-v2-regulator.c
++++ b/drivers/regulator/rpi-panel-v2-regulator.c
+@@ -8,6 +8,7 @@
+ #include <linux/err.h>
+ #include <linux/fb.h>
+ #include <linux/gpio.h>
++#include <linux/of_device.h>
+ #include <linux/gpio/driver.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+@@ -27,6 +28,11 @@
+ 
+ #define NUM_GPIO	2
+ 
++enum rpi_panel_v2_variant {
++	RPI_PANEL_V2_VARIANT_RPI = 0,
++	RPI_PANEL_V2_VARIANT_OSOYOO,
++};
++
+ struct rpi_panel_v2_lcd {
+ 	struct mutex lock;
+ 	struct regmap *regmap;
+@@ -122,11 +128,15 @@ static int rpi_panel_v2_i2c_probe(struct i2c_client *i2c,
+ {
+ 	struct backlight_properties props = { };
+ 	struct backlight_device *bl;
+ 	struct rpi_panel_v2_lcd *state;
++	enum rpi_panel_v2_variant variant = RPI_PANEL_V2_VARIANT_RPI;
+ 	struct regmap *regmap;
+ 	unsigned int data;
+ 	int ret;
+ 
++	variant = (enum rpi_panel_v2_variant)(unsigned long)
++		  of_device_get_match_data(&i2c->dev);
++
+ 	state = devm_kzalloc(&i2c->dev, sizeof(*state), GFP_KERNEL);
+ 	if (!state)
+ 		return -ENOMEM;
+@@ -153,6 +166,10 @@ static int rpi_panel_v2_i2c_probe(struct i2c_client *i2c,
+ 	case 0x08:
+ 	case 0x09:
+ 		break;
++	case 0x07:
++		if (variant == RPI_PANEL_V2_VARIANT_OSOYOO)
++			break;
++		fallthrough;
+ 	default:
+ 		dev_err(&i2c->dev, "Unknown revision: 0x%02x\n", data & 0x0f);
+ 		ret = -ENODEV;
+@@ -209,7 +226,10 @@ static void rpi_panel_v2_i2c_shutdown(struct i2c_client *client)
+ }
+ 
+ static const struct of_device_id rpi_panel_v2_dt_ids[] = {
+-	{ .compatible = "raspberrypi,v2-touchscreen-panel-regulator" },
++	{ .compatible = "raspberrypi,v2-touchscreen-panel-regulator",
++	  .data = (void *)RPI_PANEL_V2_VARIANT_RPI },
++	{ .compatible = "osoyoo,touchscreen-panel-regulator",
++	  .data = (void *)RPI_PANEL_V2_VARIANT_OSOYOO },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, rpi_panel_v2_dt_ids);
+-- 
+2.43.0

--- a/kernel/rk35xx-vendor-6.1/0001-regulator-rpi-panel-v2-add-osoyoo-compatible.patch
+++ b/kernel/rk35xx-vendor-6.1/0001-regulator-rpi-panel-v2-add-osoyoo-compatible.patch
@@ -15,7 +15,7 @@ existing Raspberry Pi path, and allow revision 0x07 only for that compatible.
  1 file changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/regulator/rpi-panel-v2-regulator.c b/drivers/regulator/rpi-panel-v2-regulator.c
-index 9396445f0867..000000000000 100644
+index 9396445f0867..335224a0323d 100644
 --- a/drivers/regulator/rpi-panel-v2-regulator.c
 +++ b/drivers/regulator/rpi-panel-v2-regulator.c
 @@ -8,6 +8,7 @@

--- a/kernel/rk35xx-vendor-6.1/0002-drm-panel-add-osoyoo-7-inch-dsi-driver.patch
+++ b/kernel/rk35xx-vendor-6.1/0002-drm-panel-add-osoyoo-7-inch-dsi-driver.patch
@@ -1,0 +1,528 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruledo <ruledo@localhost>
+Date: Sat, 4 Apr 2026 00:00:00 +0000
+Subject: [PATCH] drm/panel: add Osoyoo 7-inch DSI panel driver
+
+Add a dedicated panel driver for the Osoyoo 7-inch 720x1280 DSI
+display. The translated vendor init sequence is stable on Lyra when
+the panel runs in burst video mode, so keep that mode in the driver
+instead of forcing the panel through the existing simple-panel path.
+
+This keeps the Osoyoo support additive and board-opt-in.
+---
+diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
+index 32eae02..9a46d15 100644
+--- a/drivers/gpu/drm/panel/Kconfig
++++ b/drivers/gpu/drm/panel/Kconfig
+@@ -422,6 +422,14 @@ config DRM_PANEL_ORISETECH_OTM8009A
+ 	  Say Y here if you want to enable support for Orise Technology
+ 	  otm8009a 480x800 dsi 2dl panel.
+ 
++config DRM_PANEL_OSOYOO_DSI
++	tristate "Osoyoo 7-inch DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	help
++	  Say Y here if you want to enable support for the Osoyoo
++	  7-inch 720x1280 DSI panel.
++
+ config DRM_PANEL_OSD_OSD101T2587_53TS
+ 	tristate "OSD OSD101T2587-53TS DSI 1920x1200 video mode panel"
+ 	depends on OF
+diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
+index 5daa24e..16b2c35 100644
+--- a/drivers/gpu/drm/panel/Makefile
++++ b/drivers/gpu/drm/panel/Makefile
+@@ -40,6 +40,7 @@ obj-$(CONFIG_DRM_PANEL_MAXIM_MAX96752F) += panel-maxim-max96752f.o
+ obj-$(CONFIG_DRM_PANEL_MAXIM_MAX96772) += panel-maxim-max96772.o
+ obj-$(CONFIG_DRM_PANEL_OLIMEX_LCD_OLINUXINO) += panel-olimex-lcd-olinuxino.o
+ obj-$(CONFIG_DRM_PANEL_ORISETECH_OTM8009A) += panel-orisetech-otm8009a.o
++obj-$(CONFIG_DRM_PANEL_OSOYOO_DSI) += panel-osoyoo-dsi.o
+ obj-$(CONFIG_DRM_PANEL_OSD_OSD101T2587_53TS) += panel-osd-osd101t2587-53ts.o
+ obj-$(CONFIG_DRM_PANEL_PANASONIC_VVX10F034N00) += panel-panasonic-vvx10f034n00.o
+ obj-$(CONFIG_DRM_PANEL_RADXA_DISPLAY_8HD) += panel-radxa-display-8hd.o
+diff --git a/drivers/gpu/drm/panel/panel-osoyoo-dsi.c b/drivers/gpu/drm/panel/panel-osoyoo-dsi.c
+new file mode 100644
+index 0000000..8d82c44
+--- /dev/null
++++ b/drivers/gpu/drm/panel/panel-osoyoo-dsi.c
+@@ -0,0 +1,476 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/err.h>
++#include <linux/gpio/consumer.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/of_device.h>
++#include <linux/slab.h>
++
++#include <drm/drm_connector.h>
++#include <drm/drm_mipi_dsi.h>
++#include <drm/drm_modes.h>
++#include <drm/drm_panel.h>
++
++#include <video/mipi_display.h>
++
++enum osoyoo_op {
++	OSOYOO_SWITCH_PAGE,
++	OSOYOO_COMMAND,
++};
++
++struct osoyoo_instr {
++	enum osoyoo_op op;
++	union {
++		u8 page;
++		struct {
++			u8 cmd;
++			u8 data;
++		} cmd;
++	} arg;
++};
++
++struct osoyoo_panel_desc {
++	const struct osoyoo_instr *init;
++	size_t init_length;
++	const struct drm_display_mode *mode;
++	unsigned long mode_flags;
++	unsigned int lanes;
++};
++
++struct osoyoo_panel {
++	struct drm_panel panel;
++	struct mipi_dsi_device *dsi;
++	const struct osoyoo_panel_desc *desc;
++	struct gpio_desc *reset;
++	enum drm_panel_orientation orientation;
++};
++
++#define OSOYOO_SWITCH_PAGE_INSTR(_page) \
++	{ \
++		.op = OSOYOO_SWITCH_PAGE, \
++		.arg.page = (_page), \
++	}
++
++#define OSOYOO_COMMAND_INSTR(_cmd, _data) \
++	{ \
++		.op = OSOYOO_COMMAND, \
++		.arg.cmd = { \
++			.cmd = (_cmd), \
++			.data = (_data), \
++		}, \
++	}
++
++static inline struct osoyoo_panel *panel_to_osoyoo(struct drm_panel *panel)
++{
++	return container_of(panel, struct osoyoo_panel, panel);
++}
++
++static int osoyoo_switch_page(struct osoyoo_panel *ctx, u8 page)
++{
++	u8 seq[] = { 0xff, 0x98, 0x81, page };
++
++	return mipi_dsi_dcs_write_buffer(ctx->dsi, seq, sizeof(seq));
++}
++
++static int osoyoo_send_cmd_data(struct osoyoo_panel *ctx, u8 cmd, u8 data)
++{
++	u8 seq[] = { cmd, data };
++
++	return mipi_dsi_dcs_write_buffer(ctx->dsi, seq, sizeof(seq));
++}
++
++static const struct osoyoo_instr osoyoo_7inch_init[] = {
++	OSOYOO_SWITCH_PAGE_INSTR(3),
++	OSOYOO_COMMAND_INSTR(0x01, 0x00),
++	OSOYOO_COMMAND_INSTR(0x02, 0x00),
++	OSOYOO_COMMAND_INSTR(0x03, 0x73),
++	OSOYOO_COMMAND_INSTR(0x04, 0x00),
++	OSOYOO_COMMAND_INSTR(0x05, 0x00),
++	OSOYOO_COMMAND_INSTR(0x06, 0x0a),
++	OSOYOO_COMMAND_INSTR(0x07, 0x00),
++	OSOYOO_COMMAND_INSTR(0x08, 0x00),
++	OSOYOO_COMMAND_INSTR(0x09, 0x00),
++	OSOYOO_COMMAND_INSTR(0x0a, 0x00),
++	OSOYOO_COMMAND_INSTR(0x0b, 0x00),
++	OSOYOO_COMMAND_INSTR(0x0c, 0x01),
++	OSOYOO_COMMAND_INSTR(0x0d, 0x00),
++	OSOYOO_COMMAND_INSTR(0x0e, 0x00),
++	OSOYOO_COMMAND_INSTR(0x0f, 0x17),
++	OSOYOO_COMMAND_INSTR(0x10, 0x17),
++	OSOYOO_COMMAND_INSTR(0x11, 0x00),
++	OSOYOO_COMMAND_INSTR(0x12, 0x00),
++	OSOYOO_COMMAND_INSTR(0x13, 0x00),
++	OSOYOO_COMMAND_INSTR(0x14, 0x00),
++	OSOYOO_COMMAND_INSTR(0x15, 0x00),
++	OSOYOO_COMMAND_INSTR(0x16, 0x00),
++	OSOYOO_COMMAND_INSTR(0x17, 0x00),
++	OSOYOO_COMMAND_INSTR(0x18, 0x00),
++	OSOYOO_COMMAND_INSTR(0x19, 0x00),
++	OSOYOO_COMMAND_INSTR(0x1a, 0x00),
++	OSOYOO_COMMAND_INSTR(0x1b, 0x00),
++	OSOYOO_COMMAND_INSTR(0x1c, 0x00),
++	OSOYOO_COMMAND_INSTR(0x1d, 0x00),
++	OSOYOO_COMMAND_INSTR(0x1e, 0x40),
++	OSOYOO_COMMAND_INSTR(0x1f, 0x80),
++	OSOYOO_COMMAND_INSTR(0x20, 0x06),
++	OSOYOO_COMMAND_INSTR(0x21, 0x01),
++	OSOYOO_COMMAND_INSTR(0x22, 0x00),
++	OSOYOO_COMMAND_INSTR(0x23, 0x00),
++	OSOYOO_COMMAND_INSTR(0x24, 0x00),
++	OSOYOO_COMMAND_INSTR(0x25, 0x00),
++	OSOYOO_COMMAND_INSTR(0x26, 0x00),
++	OSOYOO_COMMAND_INSTR(0x27, 0x00),
++	OSOYOO_COMMAND_INSTR(0x28, 0x33),
++	OSOYOO_COMMAND_INSTR(0x29, 0x03),
++	OSOYOO_COMMAND_INSTR(0x2a, 0x00),
++	OSOYOO_COMMAND_INSTR(0x2b, 0x00),
++	OSOYOO_COMMAND_INSTR(0x2c, 0x00),
++	OSOYOO_COMMAND_INSTR(0x2d, 0x00),
++	OSOYOO_COMMAND_INSTR(0x2e, 0x00),
++	OSOYOO_COMMAND_INSTR(0x2f, 0x00),
++	OSOYOO_COMMAND_INSTR(0x30, 0x00),
++	OSOYOO_COMMAND_INSTR(0x31, 0x00),
++	OSOYOO_COMMAND_INSTR(0x32, 0x00),
++	OSOYOO_COMMAND_INSTR(0x33, 0x00),
++	OSOYOO_COMMAND_INSTR(0x34, 0x04),
++	OSOYOO_COMMAND_INSTR(0x35, 0x00),
++	OSOYOO_COMMAND_INSTR(0x36, 0x00),
++	OSOYOO_COMMAND_INSTR(0x37, 0x00),
++	OSOYOO_COMMAND_INSTR(0x38, 0x3c),
++	OSOYOO_COMMAND_INSTR(0x39, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3a, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3b, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3c, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3d, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3e, 0x00),
++	OSOYOO_COMMAND_INSTR(0x3f, 0x00),
++	OSOYOO_COMMAND_INSTR(0x40, 0x00),
++	OSOYOO_COMMAND_INSTR(0x41, 0x00),
++	OSOYOO_COMMAND_INSTR(0x42, 0x00),
++	OSOYOO_COMMAND_INSTR(0x43, 0x00),
++	OSOYOO_COMMAND_INSTR(0x44, 0x00),
++	OSOYOO_COMMAND_INSTR(0x50, 0x10),
++	OSOYOO_COMMAND_INSTR(0x51, 0x32),
++	OSOYOO_COMMAND_INSTR(0x52, 0x54),
++	OSOYOO_COMMAND_INSTR(0x53, 0x76),
++	OSOYOO_COMMAND_INSTR(0x54, 0x98),
++	OSOYOO_COMMAND_INSTR(0x55, 0xba),
++	OSOYOO_COMMAND_INSTR(0x56, 0x10),
++	OSOYOO_COMMAND_INSTR(0x57, 0x32),
++	OSOYOO_COMMAND_INSTR(0x58, 0x54),
++	OSOYOO_COMMAND_INSTR(0x59, 0x76),
++	OSOYOO_COMMAND_INSTR(0x5a, 0x98),
++	OSOYOO_COMMAND_INSTR(0x5b, 0xba),
++	OSOYOO_COMMAND_INSTR(0x5c, 0xdc),
++	OSOYOO_COMMAND_INSTR(0x5d, 0xfe),
++	OSOYOO_COMMAND_INSTR(0x5e, 0x00),
++	OSOYOO_COMMAND_INSTR(0x5f, 0x0e),
++	OSOYOO_COMMAND_INSTR(0x60, 0x0f),
++	OSOYOO_COMMAND_INSTR(0x61, 0x0c),
++	OSOYOO_COMMAND_INSTR(0x62, 0x0d),
++	OSOYOO_COMMAND_INSTR(0x63, 0x06),
++	OSOYOO_COMMAND_INSTR(0x64, 0x07),
++	OSOYOO_COMMAND_INSTR(0x65, 0x02),
++	OSOYOO_COMMAND_INSTR(0x66, 0x02),
++	OSOYOO_COMMAND_INSTR(0x67, 0x02),
++	OSOYOO_COMMAND_INSTR(0x68, 0x02),
++	OSOYOO_COMMAND_INSTR(0x69, 0x01),
++	OSOYOO_COMMAND_INSTR(0x6a, 0x00),
++	OSOYOO_COMMAND_INSTR(0x6b, 0x02),
++	OSOYOO_COMMAND_INSTR(0x6c, 0x15),
++	OSOYOO_COMMAND_INSTR(0x6d, 0x14),
++	OSOYOO_COMMAND_INSTR(0x6e, 0x02),
++	OSOYOO_COMMAND_INSTR(0x6f, 0x02),
++	OSOYOO_COMMAND_INSTR(0x70, 0x02),
++	OSOYOO_COMMAND_INSTR(0x71, 0x02),
++	OSOYOO_COMMAND_INSTR(0x72, 0x02),
++	OSOYOO_COMMAND_INSTR(0x73, 0x02),
++	OSOYOO_COMMAND_INSTR(0x74, 0x02),
++	OSOYOO_COMMAND_INSTR(0x75, 0x0e),
++	OSOYOO_COMMAND_INSTR(0x76, 0x0f),
++	OSOYOO_COMMAND_INSTR(0x77, 0x0c),
++	OSOYOO_COMMAND_INSTR(0x78, 0x0d),
++	OSOYOO_COMMAND_INSTR(0x79, 0x06),
++	OSOYOO_COMMAND_INSTR(0x7a, 0x07),
++	OSOYOO_COMMAND_INSTR(0x7b, 0x02),
++	OSOYOO_COMMAND_INSTR(0x7c, 0x02),
++	OSOYOO_COMMAND_INSTR(0x7d, 0x02),
++	OSOYOO_COMMAND_INSTR(0x7e, 0x02),
++	OSOYOO_COMMAND_INSTR(0x7f, 0x01),
++	OSOYOO_COMMAND_INSTR(0x80, 0x00),
++	OSOYOO_COMMAND_INSTR(0x81, 0x02),
++	OSOYOO_COMMAND_INSTR(0x82, 0x14),
++	OSOYOO_COMMAND_INSTR(0x83, 0x15),
++	OSOYOO_COMMAND_INSTR(0x84, 0x02),
++	OSOYOO_COMMAND_INSTR(0x85, 0x02),
++	OSOYOO_COMMAND_INSTR(0x86, 0x02),
++	OSOYOO_COMMAND_INSTR(0x87, 0x02),
++	OSOYOO_COMMAND_INSTR(0x88, 0x02),
++	OSOYOO_COMMAND_INSTR(0x89, 0x02),
++	OSOYOO_COMMAND_INSTR(0x8a, 0x02),
++	OSOYOO_SWITCH_PAGE_INSTR(4),
++	OSOYOO_COMMAND_INSTR(0x6c, 0x15),
++	OSOYOO_COMMAND_INSTR(0x6e, 0x2a),
++	OSOYOO_COMMAND_INSTR(0x6f, 0x37),
++	OSOYOO_COMMAND_INSTR(0x3b, 0x98),
++	OSOYOO_COMMAND_INSTR(0x3a, 0x94),
++	OSOYOO_COMMAND_INSTR(0x8d, 0x1f),
++	OSOYOO_COMMAND_INSTR(0x87, 0xba),
++	OSOYOO_COMMAND_INSTR(0x26, 0x76),
++	OSOYOO_COMMAND_INSTR(0xb2, 0xd1),
++	OSOYOO_COMMAND_INSTR(0xb5, 0x06),
++	OSOYOO_COMMAND_INSTR(0x38, 0x01),
++	OSOYOO_COMMAND_INSTR(0x39, 0x00),
++	OSOYOO_SWITCH_PAGE_INSTR(1),
++	OSOYOO_COMMAND_INSTR(0xb7, 0x03),
++	OSOYOO_COMMAND_INSTR(0x22, 0x0a),
++	OSOYOO_COMMAND_INSTR(0x2e, 0xc8),
++	OSOYOO_COMMAND_INSTR(0x31, 0x00),
++	OSOYOO_COMMAND_INSTR(0x53, 0x5d),
++	OSOYOO_COMMAND_INSTR(0x55, 0x5d),
++	OSOYOO_COMMAND_INSTR(0x40, 0x33),
++	OSOYOO_COMMAND_INSTR(0x50, 0x85),
++	OSOYOO_COMMAND_INSTR(0x51, 0x85),
++	OSOYOO_COMMAND_INSTR(0x60, 0x26),
++	OSOYOO_COMMAND_INSTR(0xa0, 0x08),
++	OSOYOO_COMMAND_INSTR(0xa1, 0x0b),
++	OSOYOO_COMMAND_INSTR(0xa2, 0x18),
++	OSOYOO_COMMAND_INSTR(0xa3, 0x15),
++	OSOYOO_COMMAND_INSTR(0xa4, 0x16),
++	OSOYOO_COMMAND_INSTR(0xa5, 0x29),
++	OSOYOO_COMMAND_INSTR(0xa6, 0x1e),
++	OSOYOO_COMMAND_INSTR(0xa7, 0x1e),
++	OSOYOO_COMMAND_INSTR(0xa8, 0x57),
++	OSOYOO_COMMAND_INSTR(0xa9, 0x1c),
++	OSOYOO_COMMAND_INSTR(0xaa, 0x2a),
++	OSOYOO_COMMAND_INSTR(0xab, 0x43),
++	OSOYOO_COMMAND_INSTR(0xac, 0x1f),
++	OSOYOO_COMMAND_INSTR(0xad, 0x20),
++	OSOYOO_COMMAND_INSTR(0xae, 0x52),
++	OSOYOO_COMMAND_INSTR(0xaf, 0x2a),
++	OSOYOO_COMMAND_INSTR(0xb0, 0x30),
++	OSOYOO_COMMAND_INSTR(0xb1, 0x32),
++	OSOYOO_COMMAND_INSTR(0xb2, 0x60),
++	OSOYOO_COMMAND_INSTR(0xb3, 0x39),
++	OSOYOO_COMMAND_INSTR(0xc0, 0x08),
++	OSOYOO_COMMAND_INSTR(0xc1, 0x24),
++	OSOYOO_COMMAND_INSTR(0xc2, 0x2e),
++	OSOYOO_COMMAND_INSTR(0xc3, 0x0d),
++	OSOYOO_COMMAND_INSTR(0xc4, 0x12),
++	OSOYOO_COMMAND_INSTR(0xc5, 0x23),
++	OSOYOO_COMMAND_INSTR(0xc6, 0x18),
++	OSOYOO_COMMAND_INSTR(0xc7, 0x1b),
++	OSOYOO_COMMAND_INSTR(0xc8, 0x85),
++	OSOYOO_COMMAND_INSTR(0xc9, 0x1b),
++	OSOYOO_COMMAND_INSTR(0xca, 0x27),
++	OSOYOO_COMMAND_INSTR(0xcb, 0x75),
++	OSOYOO_COMMAND_INSTR(0xcc, 0x1a),
++	OSOYOO_COMMAND_INSTR(0xcd, 0x18),
++	OSOYOO_COMMAND_INSTR(0xce, 0x50),
++	OSOYOO_COMMAND_INSTR(0xcf, 0x22),
++	OSOYOO_COMMAND_INSTR(0xd0, 0x22),
++	OSOYOO_COMMAND_INSTR(0xd1, 0x50),
++	OSOYOO_COMMAND_INSTR(0xd2, 0x67),
++	OSOYOO_COMMAND_INSTR(0xd3, 0x39),
++};
++
++static const struct drm_display_mode osoyoo_7inch_mode = {
++	.clock = 51200,
++	.hdisplay = 720,
++	.hsync_start = 720 + 20,
++	.hsync_end = 720 + 20 + 6,
++	.htotal = 720 + 20 + 6 + 10,
++	.vdisplay = 1280,
++	.vsync_start = 1280 + 50,
++	.vsync_end = 1280 + 50 + 6,
++	.vtotal = 1280 + 50 + 6 + 20,
++	.width_mm = 90,
++	.height_mm = 151,
++};
++
++static const struct osoyoo_panel_desc osoyoo_7inch_desc = {
++	.init = osoyoo_7inch_init,
++	.init_length = ARRAY_SIZE(osoyoo_7inch_init),
++	.mode = &osoyoo_7inch_mode,
++	.mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++		      MIPI_DSI_MODE_LPM,
++	.lanes = 2,
++};
++
++static int osoyoo_panel_prepare(struct drm_panel *panel)
++{
++	struct osoyoo_panel *ctx = panel_to_osoyoo(panel);
++	unsigned int i;
++	int ret;
++
++	if (ctx->reset) {
++		gpiod_set_value_cansleep(ctx->reset, 0);
++		msleep(60);
++		gpiod_set_value_cansleep(ctx->reset, 1);
++		msleep(60);
++	}
++
++	for (i = 0; i < ctx->desc->init_length; i++) {
++		const struct osoyoo_instr *instr = &ctx->desc->init[i];
++
++		if (instr->op == OSOYOO_SWITCH_PAGE)
++			ret = osoyoo_switch_page(ctx, instr->arg.page);
++		else
++			ret = osoyoo_send_cmd_data(ctx, instr->arg.cmd.cmd,
++						   instr->arg.cmd.data);
++		if (ret < 0)
++			return ret;
++	}
++
++	ret = osoyoo_switch_page(ctx, 0);
++	if (ret < 0)
++		return ret;
++
++	ret = mipi_dsi_dcs_set_tear_on(ctx->dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
++	if (ret < 0)
++		return ret;
++
++	ret = mipi_dsi_dcs_exit_sleep_mode(ctx->dsi);
++	if (ret < 0)
++		return ret;
++
++	msleep(120);
++
++	return mipi_dsi_dcs_set_display_on(ctx->dsi);
++}
++
++static int osoyoo_panel_enable(struct drm_panel *panel)
++{
++	return 0;
++}
++
++static int osoyoo_panel_disable(struct drm_panel *panel)
++{
++	return 0;
++}
++
++static int osoyoo_panel_unprepare(struct drm_panel *panel)
++{
++	struct osoyoo_panel *ctx = panel_to_osoyoo(panel);
++
++	mipi_dsi_dcs_set_display_off(ctx->dsi);
++	mipi_dsi_dcs_enter_sleep_mode(ctx->dsi);
++
++	if (ctx->reset)
++		gpiod_set_value_cansleep(ctx->reset, 0);
++
++	return 0;
++}
++
++static int osoyoo_panel_get_modes(struct drm_panel *panel,
++				  struct drm_connector *connector)
++{
++	struct osoyoo_panel *ctx = panel_to_osoyoo(panel);
++	struct drm_display_mode *mode;
++
++	mode = drm_mode_duplicate(connector->dev, ctx->desc->mode);
++	if (!mode) {
++		dev_err(&ctx->dsi->dev, "failed to add mode %ux%ux@%u\n",
++			ctx->desc->mode->hdisplay,
++			ctx->desc->mode->vdisplay,
++			drm_mode_vrefresh(ctx->desc->mode));
++		return -ENOMEM;
++	}
++
++	drm_mode_set_name(mode);
++	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
++	drm_mode_probed_add(connector, mode);
++
++	connector->display_info.width_mm = mode->width_mm;
++	connector->display_info.height_mm = mode->height_mm;
++	drm_connector_set_panel_orientation(connector, ctx->orientation);
++
++	return 1;
++}
++
++static enum drm_panel_orientation
++osoyoo_panel_get_orientation(struct drm_panel *panel)
++{
++	struct osoyoo_panel *ctx = panel_to_osoyoo(panel);
++
++	return ctx->orientation;
++}
++
++static const struct drm_panel_funcs osoyoo_panel_funcs = {
++	.prepare = osoyoo_panel_prepare,
++	.unprepare = osoyoo_panel_unprepare,
++	.enable = osoyoo_panel_enable,
++	.disable = osoyoo_panel_disable,
++	.get_modes = osoyoo_panel_get_modes,
++	.get_orientation = osoyoo_panel_get_orientation,
++};
++
++static int osoyoo_panel_dsi_probe(struct mipi_dsi_device *dsi)
++{
++	struct osoyoo_panel *ctx;
++	int ret;
++
++	ctx = devm_kzalloc(&dsi->dev, sizeof(*ctx), GFP_KERNEL);
++	if (!ctx)
++		return -ENOMEM;
++
++	mipi_dsi_set_drvdata(dsi, ctx);
++	ctx->dsi = dsi;
++	ctx->desc = of_device_get_match_data(&dsi->dev);
++
++	drm_panel_init(&ctx->panel, &dsi->dev, &osoyoo_panel_funcs,
++		       DRM_MODE_CONNECTOR_DSI);
++
++	ctx->reset = devm_gpiod_get_optional(&dsi->dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(ctx->reset))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->reset),
++				     "failed to get reset gpio\n");
++
++	ret = of_drm_get_panel_orientation(dsi->dev.of_node, &ctx->orientation);
++	if (ret) {
++		dev_err(&dsi->dev, "%pOF: failed to get orientation: %d\n",
++			dsi->dev.of_node, ret);
++		return ret;
++	}
++
++	drm_panel_add(&ctx->panel);
++
++	dsi->mode_flags = ctx->desc->mode_flags;
++	dsi->format = MIPI_DSI_FMT_RGB888;
++	dsi->lanes = ctx->desc->lanes;
++
++	return mipi_dsi_attach(dsi);
++}
++
++static void osoyoo_panel_dsi_remove(struct mipi_dsi_device *dsi)
++{
++	struct osoyoo_panel *ctx = mipi_dsi_get_drvdata(dsi);
++
++	mipi_dsi_detach(dsi);
++	drm_panel_remove(&ctx->panel);
++	if (ctx->reset)
++		gpiod_set_value_cansleep(ctx->reset, 0);
++}
++
++static const struct of_device_id osoyoo_panel_of_match[] = {
++	{ .compatible = "osoyoo,dsi-7inch", .data = &osoyoo_7inch_desc },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, osoyoo_panel_of_match);
++
++static struct mipi_dsi_driver osoyoo_panel_driver = {
++	.probe = osoyoo_panel_dsi_probe,
++	.remove = osoyoo_panel_dsi_remove,
++	.driver = {
++		.name = "osoyoo-panel-dsi",
++		.of_match_table = osoyoo_panel_of_match,
++	},
++};
++module_mipi_dsi_driver(osoyoo_panel_driver);
++
++MODULE_DESCRIPTION("Osoyoo 7-inch DSI panel driver");
++MODULE_AUTHOR("Ruledo");
++MODULE_LICENSE("GPL");
+
+-- 
+2.43.0

--- a/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
+++ b/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
@@ -35,12 +35,12 @@
 };
 
 &dsi_panel {
-	compatible = "osoyoo,dsi-7inch", "simple-panel-dsi";
+	compatible = "osoyoo,dsi-7inch";
 	status = "okay";
 
 	power-supply = <&vcc_3v3>;
 	backlight = <&display_mcu>;
-	reset-gpios = <&display_mcu 0 1>;
+	reset-gpios = <&display_mcu 0 0>;
 
 	prepare-delay-ms = <0>;
 	reset-delay-ms = <60>;

--- a/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
+++ b/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Configure Luckfox Lyra Zero W for the Osoyoo 7-inch 720x1280 DSI panel.
+ *
+ * This overlay is additive and opt-in. It does not replace the default Lyra
+ * display path unless user_overlays explicitly selects it.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable Osoyoo 7-inch 720x1280 DSI panel on luckfox-lyra-zero-w";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "display";
+		description = "Switch DSI panel, touch, and backlight to the Osoyoo 7-inch DSI profile.";
+	};
+
+	fragment@10 {
+		target-path = "/";
+
+		__overlay__ {
+			touch_reg: touch-reg {
+				compatible = "regulator-fixed";
+				regulator-name = "touch_reg_1";
+				gpio = <&display_mcu 1 0>;
+				startup-delay-us = <50000>;
+				enable-active-high;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&dsi_panel {
+	compatible = "osoyoo,dsi-7inch", "simple-panel-dsi";
+	status = "okay";
+
+	power-supply = <&vcc_3v3>;
+	backlight = <&display_mcu>;
+	reset-gpios = <&display_mcu 0 1>;
+
+	prepare-delay-ms = <0>;
+	reset-delay-ms = <60>;
+	init-delay-ms = <60>;
+	disable-delay-ms = <0>;
+	unprepare-delay-ms = <0>;
+	bpc = <8>;
+
+	dsi,flags = <0x00000801>;
+	dsi,format = <0>;
+	dsi,lanes = <2>;
+
+	width-mm = <90>;
+	height-mm = <151>;
+
+	panel-init-sequence = [
+		39 00 04 ff 98 81 03 15 00 02 01 00 15 00 02 02 00 15 00 02 03 73
+		15 00 02 04 00 15 00 02 05 00 15 00 02 06 0a 15 00 02 07 00
+		15 00 02 08 00 15 00 02 09 00 15 00 02 0a 00 15 00 02 0b 00
+		15 00 02 0c 01 15 00 02 0d 00 15 00 02 0e 00 15 00 02 0f 17
+		15 00 02 10 17 15 00 02 11 00 15 00 02 12 00 15 00 02 13 00
+		15 00 02 14 00 15 00 02 15 00 15 00 02 16 00 15 00 02 17 00
+		15 00 02 18 00 15 00 02 19 00 15 00 02 1a 00 15 00 02 1b 00
+		15 00 02 1c 00 15 00 02 1d 00 15 00 02 1e 40 15 00 02 1f 80
+		15 00 02 20 06 15 00 02 21 01 15 00 02 22 00 15 00 02 23 00
+		15 00 02 24 00 15 00 02 25 00 15 00 02 26 00 15 00 02 27 00
+		15 00 02 28 33 15 00 02 29 03 15 00 02 2a 00 15 00 02 2b 00
+		15 00 02 2c 00 15 00 02 2d 00 15 00 02 2e 00 15 00 02 2f 00
+		15 00 02 30 00 15 00 02 31 00 15 00 02 32 00 15 00 02 33 00
+		15 00 02 34 04 15 00 02 35 00 15 00 02 36 00 15 00 02 37 00
+		15 00 02 38 3c 15 00 02 39 00 15 00 02 3a 00 15 00 02 3b 00
+		15 00 02 3c 00 15 00 02 3d 00 15 00 02 3e 00 15 00 02 3f 00
+		15 00 02 40 00 15 00 02 41 00 15 00 02 42 00 15 00 02 43 00
+		15 00 02 44 00 15 00 02 50 10 15 00 02 51 32 15 00 02 52 54
+		15 00 02 53 76 15 00 02 54 98 15 00 02 55 ba 15 00 02 56 10
+		15 00 02 57 32 15 00 02 58 54 15 00 02 59 76 15 00 02 5a 98
+		15 00 02 5b ba 15 00 02 5c dc 15 00 02 5d fe 15 00 02 5e 00
+		15 00 02 5f 0e 15 00 02 60 0f 15 00 02 61 0c 15 00 02 62 0d
+		15 00 02 63 06 15 00 02 64 07 15 00 02 65 02 15 00 02 66 02
+		15 00 02 67 02 15 00 02 68 02 15 00 02 69 01 15 00 02 6a 00
+		15 00 02 6b 02 15 00 02 6c 15 15 00 02 6d 14 15 00 02 6e 02
+		15 00 02 6f 02 15 00 02 70 02 15 00 02 71 02 15 00 02 72 02
+		15 00 02 73 02 15 00 02 74 02 15 00 02 75 0e 15 00 02 76 0f
+		15 00 02 77 0c 15 00 02 78 0d 15 00 02 79 06 15 00 02 7a 07
+		15 00 02 7b 02 15 00 02 7c 02 15 00 02 7d 02 15 00 02 7e 02
+		15 00 02 7f 01 15 00 02 80 00 15 00 02 81 02 15 00 02 82 14
+		15 00 02 83 15 15 00 02 84 02 15 00 02 85 02 15 00 02 86 02
+		15 00 02 87 02 15 00 02 88 02 15 00 02 89 02 15 00 02 8a 02
+		39 00 04 ff 98 81 04 15 00 02 6c 15 15 00 02 6e 2a 15 00 02 6f 37
+		15 00 02 3b 98 15 00 02 3a 94 15 00 02 8d 1f 15 00 02 87 ba
+		15 00 02 26 76 15 00 02 b2 d1 15 00 02 b5 06 15 00 02 38 01
+		15 00 02 39 00 39 00 04 ff 98 81 01 15 00 02 b7 03 15 00 02 22 0a
+		15 00 02 2e c8 15 00 02 31 00 15 00 02 53 5d 15 00 02 55 5d
+		15 00 02 40 33 15 00 02 50 85 15 00 02 51 85 15 00 02 60 26
+		15 00 02 a0 08 15 00 02 a1 0b 15 00 02 a2 18 15 00 02 a3 15
+		15 00 02 a4 16 15 00 02 a5 29 15 00 02 a6 1e 15 00 02 a7 1e
+		15 00 02 a8 57 15 00 02 a9 1c 15 00 02 aa 2a 15 00 02 ab 43
+		15 00 02 ac 1f 15 00 02 ad 20 15 00 02 ae 52 15 00 02 af 2a
+		15 00 02 b0 30 15 00 02 b1 32 15 00 02 b2 60 15 00 02 b3 39
+		15 00 02 c0 08 15 00 02 c1 24 15 00 02 c2 2e 15 00 02 c3 0d
+		15 00 02 c4 12 15 00 02 c5 23 15 00 02 c6 18 15 00 02 c7 1b
+		15 00 02 c8 85 15 00 02 c9 1b 15 00 02 ca 27 15 00 02 cb 75
+		15 00 02 cc 1a 15 00 02 cd 18 15 00 02 ce 50 15 00 02 cf 22
+		15 00 02 d0 22 15 00 02 d1 50 15 00 02 d2 67 15 00 02 d3 39
+		39 00 04 ff 98 81 00 15 00 02 35 00 05 78 01 11 05 00 01 29
+	];
+
+	panel-exit-sequence = [
+		05 00 01 28
+		05 78 01 10
+	];
+};
+
+&i2c2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <50000>;
+
+	/delete-node/ ws-bl@45;
+	/delete-node/ gt9271@5d;
+	/delete-node/ gt911@14;
+	/delete-node/ ft5406@38;
+
+	display_mcu: display_mcu@45 {
+		compatible = "osoyoo,touchscreen-panel-regulator";
+		reg = <0x45>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "okay";
+	};
+
+	gt911: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		AVDD28-supply = <&touch_reg>;
+		VDDIO-supply = <&vcc_3v3>;
+		touchscreen-size-x = <720>;
+		touchscreen-size-y = <1280>;
+		touchscreen-x-mm = <87>;
+		touchscreen-y-mm = <155>;
+		status = "okay";
+	};
+};
+
+&disp_timings0 {
+	native-mode = <&dsi_timing1>;
+};
+
+&dsi_timing1 {
+	clock-frequency = <51200000>;
+	hactive = <720>;
+	vactive = <1280>;
+
+	hsync-len = <6>;
+	hback-porch = <10>;
+	hfront-porch = <20>;
+
+	vsync-len = <6>;
+	vback-porch = <20>;
+	vfront-porch = <50>;
+
+	hsync-active = <0>;
+	vsync-active = <0>;
+	de-active = <0>;
+	pixelclk-active = <0>;
+};

--- a/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
+++ b/overlay/dtbo/rockchip/luckfox-lyra-zero-w-osoyoo-7inch-dsi.dts
@@ -119,11 +119,6 @@
 	#size-cells = <0>;
 	clock-frequency = <50000>;
 
-	/delete-node/ ws-bl@45;
-	/delete-node/ gt9271@5d;
-	/delete-node/ gt911@14;
-	/delete-node/ ft5406@38;
-
 	display_mcu: display_mcu@45 {
 		compatible = "osoyoo,touchscreen-panel-regulator";
 		reg = <0x45>;
@@ -132,7 +127,7 @@
 		status = "okay";
 	};
 
-	gt911: gt911@5d {
+	display_gt911: gt911@5d {
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		AVDD28-supply = <&touch_reg>;
@@ -166,4 +161,20 @@
 	vsync-active = <0>;
 	de-active = <0>;
 	pixelclk-active = <0>;
+};
+
+&gt9271 {
+	status = "disabled";
+};
+
+&gt911 {
+	status = "disabled";
+};
+
+&ft5406 {
+	status = "disabled";
+};
+
+&ws_bl {
+	status = "disabled";
 };


### PR DESCRIPTION
## What changed

This keeps the Osoyoo display support opt-in for Lyra Zero W.

Changes in this branch:
- keep the Osoyoo regulator fix
- add a dedicated Osoyoo panel driver
- update the Lyra Osoyoo overlay to bind that driver

## Why

The earlier overlay-only path could power the panel and draw to it, but the
image still wrapped on the live board.

The working fix was to use a dedicated panel driver and run the panel in
burst video mode.

## Tested

Tested on a live Luckfox Lyra Zero W with the Osoyoo 7-inch 720x1280 DSI
panel. The display comes up and the wrap issue is gone.