### PR TITLE
Add missing Foxbuntu kernel drivers

### DIFF
--- a/global-config.conf
+++ b/global-config.conf
@@ -23,3 +23,47 @@ DEB_COMPRESS=xz
 NETWORKING_STACK="network-manager"
 EXTRAWIFI=yes
 COMPRESS_OUTPUTIMAGE="xz,sha"
+
+# Add the Foxbuntu-derived driver set that is still missing from the
+# current vendor kernel config, keeping everything modular where possible.
+function custom_kernel_config__needsupstream() {
+	opts_y+=(
+		RTC_DRV_DS1307_CENTURY
+	)
+
+	opts_m+=(
+		ATH10K_SDIO
+		ATH6KL_SDIO
+		MT7663S
+		NTFS_FS
+		RTC_DRV_DS1307
+		RTC_DRV_PCF85063
+		RTC_DRV_RV8803
+		TUN
+		USB_IPHETH
+		USB_LAN78XX
+		USB_RTL8152
+		USB_SERIAL_CH341
+		USB_SERIAL_CP210X
+		USB_SERIAL_SIMPLE
+		USB_USBNET
+		USB_NET_AQC111
+		USB_NET_CDC_EEM
+		USB_NET_CDC_MBIM
+		USB_NET_CH9200
+		USB_NET_DM9601
+		USB_NET_HUAWEI_CDC_NCM
+		USB_NET_MCS7830
+		USB_NET_QMI_WWAN
+		USB_NET_RNDIS_HOST
+		USB_NET_SMSC75XX
+		USB_NET_SMSC95XX
+		USB_NET_SR9700
+		USB_NET_SR9800
+		USB_SIERRA_NET
+		WCN36XX
+		WILC1000_SDIO
+		WILC1000_SPI
+		ZD1211RW
+	)
+}


### PR DESCRIPTION
Add a kernel config hook in global-config.conf for the Foxbuntu drivers that are still missing from the current mPWRD-OS vendor kernel config.

Keep the added drivers modular where possible.
