### PR TITLE
Extension: armbian-web-config

### DIFF
--- a/.github/workflows/build-armbian.yaml
+++ b/.github/workflows/build-armbian.yaml
@@ -24,9 +24,9 @@ jobs:
           - config: luckfox-lyra-plus
             armbian_ref: v26.2.0-trunk.715 # Dev
           - config: luckfox-lyra-ultra-w
-            armbian_ref: v26.2.0-trunk.715 # Dev
+            armbian_ref: 5c507061c13f81288a2d6d62be3070dc4775d3f0 # Dev
           - config: luckfox-lyra-zero-w
-            armbian_ref: v26.2.0-trunk.715 # Dev
+            armbian_ref: 5c507061c13f81288a2d6d62be3070dc4775d3f0 # Dev
           - config: luckfox-pico-max
             armbian_ref: v26.2.0-trunk.715 # Dev
           - config: luckfox-pico-mini

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 ## Features
 - 🐧 Debian 13 `trixie` based.
 - ❤️ Built with [Armbian](https://armbian.com/) *userpatches* framework.
-- 🛜 [meshtasticd](https://meshtastic.org/docs/hardware/devices/linux-native-hardware/) pre-installed and working out of the box.
+- Ⓜ️ [meshtasticd](https://meshtastic.org/docs/hardware/devices/linux-native-hardware/) pre-installed and working out of the box.
 - 🐍 [meshtastic](https://meshtastic.org/docs/software/python/cli/) CLI pre-installed.
 - 📡 [contact](https://github.com/pdxlocations/contact) Meshtastic TUI pre-installed.
 - 🧙 [mpwrd-menu](https://github.com/mPWRD-OS/mpwrd-menu) simple OS / Meshtastic management utility.
 - 🔵 BLE WiFi provisioning via the Meshtastic Apps / Flasher.
-  - Powered by 🏠 [Nymea-NetworkManager](https://github.com/nymea/nymea-networkmanager)
-  - Currently only supported on Raspberry Pi.
+  - Powered by 🏠 [Nymea-NetworkManager](https://github.com/nymea/nymea-networkmanager).
+  - Supported on Raspberry Pi.
+- 🛜 WiFi provisioning via temporary `armbiansetup` hotspot.
+  - Powered by 🌐 [armbian-web-config](https://github.com/Grippy98/armbian-web-config).
+  - Supported on Luckfox Lyra Zero W and Luckfox Lyra Ultra W with more to come.
 
 ## Board Support
 

--- a/config-luckfox-lyra-ultra-w.conf
+++ b/config-luckfox-lyra-ultra-w.conf
@@ -4,4 +4,4 @@ source family-rk3506.conf
 
 # Board-specific
 BOARD=luckfox-lyra-ultra-w
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,unblock-rfkill"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,unblock-rfkill,armbian-web-config"

--- a/config-luckfox-lyra-zero-w.conf
+++ b/config-luckfox-lyra-zero-w.conf
@@ -4,7 +4,7 @@ source family-rk3506.conf
 
 # Board-specific
 BOARD=luckfox-lyra-zero-w
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,unblock-rfkill"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,unblock-rfkill,armbian-web-config"
 
 # Disable UART interrupts during boot
 # preventing UART-enabled hats from interfering with uboot.

--- a/extensions/provisioning/armbian-web-config.sh
+++ b/extensions/provisioning/armbian-web-config.sh
@@ -1,0 +1,12 @@
+# Armbian Web Config
+# https://github.com/Grippy98/armbian-web-config
+
+function post_family_tweaks__install_armbian_web_config() {
+	display_alert "Extension: ${EXTENSION}" "Installing armbian-web-config" "info"
+	local deb_url="https://github.com/mPWRD-OS/armbian-web-config/releases/download/1.0-1/armbian-web-config_1.0-1_all.deb"
+	local deb_file="/tmp/armbian-web-config.deb"
+
+    chroot_sdcard "wget ${deb_url} -O ${deb_file}"
+    chroot_sdcard_apt_get_install "${deb_file}"
+	rm -f "${deb_file}"
+}


### PR DESCRIPTION
Adding [`armbian-web-config`](https://github.com/Grippy98/armbian-web-config) WiFi provisioning service.

Currently only enabling on `luckfox-lyra-zero-w` and `luckfox-lyra-ultra-w`.