### PR TITLE
luckfox-lyra-zero-w: Disable UART interrupts at boot.

### DIFF
--- a/config-luckfox-lyra-zero-w.conf
+++ b/config-luckfox-lyra-zero-w.conf
@@ -5,3 +5,9 @@ source family-rk3506.conf
 # Board-specific
 BOARD=luckfox-lyra-zero-w
 ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,unblock-rfkill"
+
+# Disable UART interrupts during boot
+# preventing UART-enabled hats from interfering with uboot.
+function post_family_config__override_bootdelay() {
+	declare -g BOOTDELAY="-2"
+}


### PR DESCRIPTION
BOOTDELAY="-2"