### PR TITLE
Add conditional warning in the MOTD

### DIFF
--- a/overlay/fs/etc/update-motd.d/97-mpwrd-warnings
+++ b/overlay/fs/etc/update-motd.d/97-mpwrd-warnings
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# mPWRD-OS Conditional Warnings
+
+set -o pipefail
+
+RED=$'\e[31m'
+GREEN=$'\e[32m'
+YELLOW=$'\e[33m'
+GREY=$'\e[90m'
+BOLD=$'\e[1m'
+RESET=$'\e[0m'
+
+# Check if Meshtastic configuration directory is empty
+if [[ -z "$(find /etc/meshtasticd/config.d -mindepth 1 -maxdepth 1 2>/dev/null)" ]]; then
+  # Ensure we aren't using Pi HAT+ or USB CH341 (SPI mode)
+  if [[ ! -d /proc/device-tree/hat ]] && ! lsusb -d 1a86:5512 &>/dev/null; then
+    echo ""
+    echo " ${YELLOW}Radio not configured!${RESET}"
+    echo " Run ${GREEN}${BOLD}mpwrd-menu${RESET} to configure this device."
+  fi
+fi


### PR DESCRIPTION
Nag the user when they don't have a board configured (or HAT+)
<img width="450" height="88" alt="image" src="https://github.com/user-attachments/assets/58e2e80f-045b-4814-b3e0-1caca01fbd83" />
