### PR TITLE
Add pico-usb-auto extension for Pico boards

### DIFF
--- a/config-luckfox-pico-max.conf
+++ b/config-luckfox-pico-max.conf
@@ -4,6 +4,7 @@ source family-rv1106.conf
 
 # Board-specific
 BOARD=luckfox-pico-max
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,pico-usb-auto"
 
 # pico-max default to alpha channel for now
 # Recently-merged configs are only present in Alpha (2.7.22)

--- a/config-luckfox-pico-mini.conf
+++ b/config-luckfox-pico-mini.conf
@@ -4,4 +4,4 @@ source family-rv1106.conf
 
 # Board-specific
 BOARD=luckfox-pico-mini
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,disable-bg-apt,perf-apt,perf-journald,perf-sources,perf-sysctl,perf-tmp-rootfs"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,disable-bg-apt,perf-apt,perf-journald,perf-sources,perf-sysctl,perf-tmp-rootfs,pico-usb-auto"

--- a/extensions/performance/pico-usb-auto.sh
+++ b/extensions/performance/pico-usb-auto.sh
@@ -1,0 +1,13 @@
+#
+# Allow the Pico USB host controller stack to runtime-suspend when idle.
+#
+function post_repo_customize_image__710_pico_usb_auto() {
+	display_alert "Extension: ${EXTENSION}" "Set Pico USB runtime PM to auto" "info"
+
+	mkdir -p "${SDCARD}/etc/udev/rules.d"
+
+	cat > "${SDCARD}/etc/udev/rules.d/99-mpwrd-usb-host-auto.rules" <<-'EOF_UDEV'
+	ACTION=="add", SUBSYSTEM=="platform", KERNEL=="ffb00000.usb", TEST=="power/control", ATTR{power/control}="auto"
+	ACTION=="add", SUBSYSTEM=="platform", KERNEL=="xhci-hcd.0.auto", TEST=="power/control", ATTR{power/control}="auto"
+	EOF_UDEV
+}


### PR DESCRIPTION
Add a performance extension that sets Pico USB runtime PM to auto through a udev rule installed into the image.

Enable the extension for luckfox-pico-mini and luckfox-pico-max.