### PR TITLE
Remove apt workarounds for i2c group

### DIFF
--- a/customize-image.sh
+++ b/customize-image.sh
@@ -43,12 +43,6 @@ case $RELEASE in
 esac
 
 Main() {
-	apt-get update
-	# meshtasticd can't currently be installed via the `meshtasticd` Extension
-	# due to a race condition with the gpio group when installing before family-tweaks.
-	InstallAptPkg "meshtasticd"
-	# Same story with i2c-tools. Race condition with i2c group in family-tweaks.
-	InstallAptPkg "i2c-tools"
 	case $pipx_g in
 		true)
 			InstallPipxPkg "meshtastic"
@@ -62,7 +56,6 @@ Main() {
 	# Always run
 	ApplyFSOverlay
 	BoardSpecific "$@"
-	apt-get clean && rm -rf /var/lib/apt/lists/*
 	CompileDTBO
 } # Main
 
@@ -71,14 +64,6 @@ ApplyFSOverlay() {
 	# replacing existing files
 	cp -r /tmp/overlay/fs/* /
 } # ApplyFSOverlay
-
-InstallAptPkg() {
-	PKGSPEC="$1"
-	# Install package via apt-get
-	echo "APT: Installing ${PKGSPEC}..."
-	apt-get --yes --allow-unauthenticated \
-		install $PKGSPEC
-} # InstallAptPkg
 
 InstallPipxPkg() {
 	PKGSPEC="$1"

--- a/extensions/meshtasticd.sh
+++ b/extensions/meshtasticd.sh
@@ -32,8 +32,6 @@ function custom_apt_repo__add_meshtasticd_repo() {
 	esac
 }
 
-# Temporarily disabled: gpio + ic2 groups race condition
-# Instead installed with customize-image.sh
-# function extension_prepare_config__add_meshtasticd() {
-# 	add_packages_to_image meshtasticd
-# }
+function extension_prepare_config__add_meshtasticd() {
+	add_packages_to_image meshtasticd
+}

--- a/extensions/mpwrd-misc-pkgs.sh
+++ b/extensions/mpwrd-misc-pkgs.sh
@@ -5,6 +5,5 @@ function extension_prepare_config__add_mpwrd_misc() {
 	# Cockpit
 	add_packages_to_image cockpit cockpit-networkmanager
 	# Misc
-	add_packages_to_image vim git net-tools fonts-noto-color-emoji
-	# re-add 'i2c-tools' here when the race condition with family-tweaks is resolved
+	add_packages_to_image vim git net-tools fonts-noto-color-emoji i2c-tools
 }


### PR DESCRIPTION
Fixed upstream

---

This pull request refactors how certain packages are installed in the image build process, resolving previous issues with package installation order and group creation race conditions. The main changes move `meshtasticd` and `i2c-tools` installation from the custom image script back into their respective extension scripts, and remove now-unnecessary helper functions from the image customization script.

**Refactoring package installation and build process:**

* Restored installation of `meshtasticd` in the extension script (`extensions/meshtasticd.sh`) by re-enabling the `extension_prepare_config__add_meshtasticd` function, moving its installation responsibility out of `customize-image.sh`.
* Added `i2c-tools` back to the list of packages installed by the `mpwrd-misc-pkgs` extension, now that the previous race condition is resolved (`extensions/mpwrd-misc-pkgs.sh`).

**Cleanup and simplification in image customization:**

* Removed direct installation of `meshtasticd` and `i2c-tools` from the `Main` function in `customize-image.sh`, as these are now handled by their respective extensions.
* Deleted the now-unused `InstallAptPkg` helper function from `customize-image.sh`.
* Removed the redundant `apt-get clean` command from the `Main` function in `customize-image.sh`.