### PR TITLE
Disable background apt on RV1106 images

### DIFF
--- a/config-luckfox-pico-mini.conf
+++ b/config-luckfox-pico-mini.conf
@@ -4,4 +4,4 @@ source family-rv1106.conf
 
 # Board-specific
 BOARD=luckfox-pico-mini
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,disable-bg-apt,perf-apt,perf-journald,perf-sources,perf-sysctl,perf-tmp-rootfs"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,perf-journald,perf-sources,perf-sysctl,perf-tmp-rootfs"

--- a/extensions/performance/disable-bg-apt.sh
+++ b/extensions/performance/disable-bg-apt.sh
@@ -27,6 +27,7 @@ function pre_umount_final_image__700_disable_bg_apt() {
 	chroot_mount chmod -x /usr/lib/armbian/armbian-apt-updates || true
 	chroot_mount chmod -x /etc/cron.daily/apt-compat || true
 	chroot_mount rm -f /etc/cron.d/armbian-updates || true
+	chroot_mount rm -f /etc/apt/apt.conf.d/02-armbian-postupdate || true
 
 	# Ensure apt periodic behavior stays disabled.
 	mkdir -p "${MOUNT}/etc/apt/apt.conf.d"

--- a/family-rv1106.conf
+++ b/family-rv1106.conf
@@ -6,4 +6,4 @@ BRANCH=vendor
 #BRANCH=edge
 
 # Family-specific extensions (optimizations)
-ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,fixed-eth-mac"
+ENABLE_EXTENSIONS="$ENABLE_EXTENSIONS,fixed-eth-mac,disable-bg-apt,perf-apt"


### PR DESCRIPTION
## Summary

Disable inherited background apt work on RV1106-family images by enabling the existing `disable-bg-apt` and `perf-apt` extensions at the family level, then removing the duplicate extension entries from `luckfox-pico-mini`.

Also harden `disable-bg-apt` by removing Armbian's `02-armbian-postupdate` hook from the final image. That hook can invoke `/usr/lib/armbian/armbian-apt-updates` after package operations, which runs apt upgrade simulation work.

## Why

Femtofox/Luckfox-class RV1106/RV1103 boards can have very limited RAM. Background apt update/accounting work can make these nodes difficult to reach over SSH and is a poor default for embedded router/backbone deployments. Manual apt usage remains available; this only disables automatic/background apt execution.

## Validation

- `bash -n extensions/performance/disable-bg-apt.sh`
- `bash -n family-rv1106.conf`
- `bash -n config-luckfox-pico-mini.conf`
- `git diff --check`